### PR TITLE
makes smtp connect work with server using tls immediate on port 465

### DIFF
--- a/smtptester/smtp.py
+++ b/smtptester/smtp.py
@@ -76,12 +76,13 @@ def send(
     log_host = f"{host.name}({host.address}):{host.port}"
     try:
         log.debug(f"Trying SMTP host: {log_host}")
-        s = smtplib.SMTP(
+        f = smtplib.SMTP_SSL if tls == 'yes' else smtplib.SMTP
+        s = f(
             host=host.address, port=host.port, timeout=timeout, local_hostname=helo
         )
         s.set_debuglevel(debuglevel)
         s.ehlo_or_helo_if_needed()
-        if tls == "yes" or (tls == "try" and s.has_extn("STARTTLS")):
+        if (tls == "try" and s.has_extn("STARTTLS")):
             s.starttls()
         if auth_user or auth_pass:
             s.login(auth_user, auth_pass)


### PR DESCRIPTION
such as gmail for example.
Note that this change could break existing scripts. 
It would be possible to add a fourth tls state such as 'immediate' and keep compatibility, but it would require complicating the gui tool UI. I could do that but IMO it's not worth the hassle, I'm open to change it of course.